### PR TITLE
Fix: Generate random initial password for HOST_USER

### DIFF
--- a/config/secrets/secrets.conf
+++ b/config/secrets/secrets.conf
@@ -2,5 +2,3 @@
 IP2TOKEN="GET_ME_FROM_IP2LOCATION.COM"
 # The username on the host machine
 HOST_USER="amadmin"
-# The hash for the $HOST_USER on the host machine
-HOST_PASS='$6$cbH7v5nNl0$CY6uKoJP3FSoGtdDMXpmFvW9hoYOA0fpXMA1jMV5GXPFeF.xIkp0RoQQVjisoGJ.d/LyG6CQZguEn6KsTVlRI.'


### PR DESCRIPTION
Previously the salted hash of the developers password was commited to the repository and used as the initial password during installation.

Instead, generate a random password during installation.